### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Protocentral Kalam board
-version=V1.0
+version=1.0
 author=Protocentral <support@protocentral.com>
 maintainer=Protocentral <protocentral.com>
 sentence=Library to getting started with Kalam.


### PR DESCRIPTION
The previous version `value` caused the Arduino IDE to display warnings:
```
Invalid version found: V1.0
```
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format